### PR TITLE
Possibly the most small-brained fix for a routing issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,8 @@ jobs:
         working-directory: svelte-app
         run: |
           echo -e "${{ github.sha }}\n$(date)" > static/version.txt && \
-          yarn build
+          yarn build && \
+          mkdir build/scan && ln -s ../assets build/scan/assets
 
       - name: Deploy to GitHub pages
         uses: peaceiris/actions-gh-pages@v3

--- a/svelte-app/vite.config.ts
+++ b/svelte-app/vite.config.ts
@@ -3,7 +3,10 @@ import type { UserConfig } from 'vite';
 import wasmPack from 'vite-plugin-wasm-pack';
 
 const config: UserConfig = {
-	plugins: [wasmPack(['./../wasm']), sveltekit()]
+	plugins: [wasmPack(['../wasm']), sveltekit()],
+	optimizeDeps: {
+		exclude: ['../wasm']
+	}
 };
 
 export default config;


### PR DESCRIPTION
Ok so the WebAssembly part of our application currently crashes (after the SvelteKit upgrade from #8) , because something in the routing got messed up and the browser tries to request `/scan/assets/wasm_bg.wasm` instead of `/assets/wasm_bg.wasm`. I suspect it has something to do with vite, but I can't for the life of me figure out why, as nothing related to that actually changed in the upgrade.

So for now I've just created a symlink to mitigate the issue. It's not a very elegant solution, but It Works™ for now.